### PR TITLE
Fix issue 11 (obsolete imports in test files resulting in issues when consumer uses go modules)

### DIFF
--- a/cmd_test.go
+++ b/cmd_test.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/ahmetalpbalkan/go-dexec"
+	"github.com/ahmetb/go-dexec"
 	"github.com/fsouza/go-dockerclient"
 	. "gopkg.in/check.v1"
 )

--- a/example_test.go
+++ b/example_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/ahmetalpbalkan/go-dexec"
+	"github.com/ahmetb/go-dexec"
 	"github.com/fsouza/go-dockerclient"
 )
 

--- a/examples/100-hello/main.go
+++ b/examples/100-hello/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/ahmetalpbalkan/go-dexec"
+	"github.com/ahmetb/go-dexec"
 	"github.com/fsouza/go-dockerclient"
 )
 

--- a/examples/200-stdin-stdout/main.go
+++ b/examples/200-stdin-stdout/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/ahmetalpbalkan/go-dexec"
+	"github.com/ahmetb/go-dexec"
 	"github.com/fsouza/go-dockerclient"
 	"os"
 	"strings"

--- a/examples/300-pipes/main.go
+++ b/examples/300-pipes/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/ahmetalpbalkan/go-dexec"
+	"github.com/ahmetb/go-dexec"
 	"github.com/fsouza/go-dockerclient"
 	"os"
 )

--- a/examples/400-exit-code/main.go
+++ b/examples/400-exit-code/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/ahmetalpbalkan/go-dexec"
+	"github.com/ahmetb/go-dexec"
 	"github.com/fsouza/go-dockerclient"
 )
 

--- a/examples/500-video-processing/main.go
+++ b/examples/500-video-processing/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/ahmetalpbalkan/go-dexec"
+	"github.com/ahmetb/go-dexec"
 	"github.com/fsouza/go-dockerclient"
 	"io/ioutil"
 )

--- a/examples/600-parallel-compute/main.go
+++ b/examples/600-parallel-compute/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/ahmetalpbalkan/go-dexec"
+	"github.com/ahmetb/go-dexec"
 	"github.com/fsouza/go-dockerclient"
 	"io/ioutil"
 	"strings"

--- a/type_test.go
+++ b/type_test.go
@@ -5,7 +5,7 @@ import (
 	osexec "os/exec"
 	"testing"
 
-	"github.com/ahmetalpbalkan/go-dexec"
+	"github.com/ahmetb/go-dexec"
 )
 
 // cmd ensures interface compatibility between os/exec.Cmd and dexec.Cmd.


### PR DESCRIPTION
Fixes https://github.com/ahmetb/go-dexec/issues/11